### PR TITLE
chore(deps): Bump libcanon and build the extensions as C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
 
 # Set C++ standard
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find Python


### PR DESCRIPTION
Stacked on #67 — the base of this PR is that branch, since drudge cannot build at all without it. Retarget to `master` once #67 merges.

## Background

`deps/libcanon` has been pinned at `6785c39` since before libcanon's own C++20 migration. Three fixes have landed upstream since:

| libcanon PR | what it fixes |
| --- | --- |
| DrudgeCAS/libcanon#7 | Out-of-bounds read in the `Sims_transv` iterator. The bounds test was written after the element access, so **every** traversal of a transversal read one `unique_ptr` past the end of its vector. Silent in practice, fatal when the allocation abuts an unmapped page, and it made any sanitizer build unusable. |
| DrudgeCAS/libcanon#8 | Build on current toolchains: googletest bumped past CMake 4.x's floor, and `std::result_of_t` replaced with `std::invoke_result_t`. |
| DrudgeCAS/libcanon#9 | Restores the degree-reverse ordering in eldag refinement, which C++20 had silently bypassed. Fixes DrudgeCAS/libcanon#6. |

The third one is the reason this bump matters for drudge rather than being routine hygiene — see below.

## Changes

- `deps/libcanon`: `6785c39` to `c54f528`.
- `CMAKE_CXX_STANDARD`: 14 to 20. libcanon now uses unguarded concepts, `operator<=>`, and `std::compare_three_way_result_t`, none of which compile as C++14. Drudge's own `canonpy.cpp` and `wickcore.cpp` need no changes and use nothing removed in C++17 or C++20.

## Why the ordering fix matters here

libcanon's `Orbit` and `Detailed_edges` derive from `std::vector` and defined their degree-reverse ordering only through `operator<`. Under C++20, `std::pair::operator<=>` synthesizes the comparison from the **base** `std::vector`'s `operator<=>`, so the derived ordering was never consulted and eldag refinement sorted lexicographically instead. libcanon's own test suite hid this: the expected canonical form in `Test_ccsd_langr` was simply edited to match the new output.

Drudge's test suite is not so forgiving. Built against the intermediate libcanon commit `3d16d82` (post-C++20-migration, pre-fix), drudge fails **10 tests with 7 errors**, concentrated exactly where you would expect:

```
FAILED tests/term_test.py::test_simple_terms_can_be_canonicalized
FAILED tests/free_algebra_test.py::test_tensor_can_be_canonicalized
FAILED tests/free_algebra_test.py::test_canonicalization_of_vectors_w_symm
FAILED tests/genmb_test.py::test_genmb_gives_conventional_dummies
FAILED tests/parthole_test.py::test_parthole_drudge_gives_conventional_dummies
ERROR  tests/nuclear_test.py::test_wigner3j_sum_to_wigner6j
...
```

So bumping to `3d16d82` would have broken drudge's canonical forms. Bumping to `c54f528` does not, because the fix restores the ordering drudge has always had.

## Verification

macOS, Apple clang 21, libc++, with #67 applied:

| libcanon pin | drudge test suite |
| --- | --- |
| `6785c39` (current pin, C++14) | 162 passed, 2 skipped |
| `3d16d82` (post-migration, pre-fix) | 10 failed, 145 passed, 2 skipped, 7 errors |
| `c54f528` (this PR) | **162 passed, 2 skipped** |

Identical to the current pin, which is the intended outcome: the canonical forms drudge produces are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
