### PR TITLE
chore(deps): Bump libcanon and build the extensions as C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
 
 # Set C++ standard
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["scikit-build-core>=0.10"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
-cmake.minimum-version = "3.15"  # Minimum version of CMake
-cmake.verbose = true  # Verbose build for debugging
+cmake.version = ">=3.15"  # Minimum version of CMake
+build.verbose = true  # Verbose build for debugging
 # Don't create a separate subdirectory - install alongside Python source files
 wheel.packages = ["drudge"]
 sdist.include = ["drudge/templates/*", "drudge/*.h", "deps/libcanon/include/**/*.h"]


### PR DESCRIPTION
Replaces #68, which GitHub closed automatically when its base branch was deleted as part of merging #67. Same branch, now targeting `master` and pointing at a newer libcanon.

## Changes

- `deps/libcanon`: `6785c39` to `e15bef1`.
- `CMAKE_CXX_STANDARD`: 14 to 20. libcanon now uses unguarded concepts, `operator<=>` and `std::compare_three_way_result_t`, none of which compile as C++14. Drudge's own `canonpy.cpp` and `wickcore.cpp` need no changes and use nothing removed in C++17 or C++20.

## What the bump picks up

Eight libcanon changes, of which five came out of a review against Jinmo Zhao's thesis:

| libcanon PR | what it fixes |
| --- | --- |
| DrudgeCAS/libcanon#7 | Out-of-bounds read on every traversal of a `Sims_transv`. |
| DrudgeCAS/libcanon#8 | Build on current toolchains. |
| DrudgeCAS/libcanon#9 | Restores the degree-reverse ordering that C++20 silently bypassed. |
| DrudgeCAS/libcanon#11 | `Partition::Cell_it` now satisfies the input-iterator requirements. **This is what unblocks the Windows build here.** |
| DrudgeCAS/libcanon#12 | A leak on every `build_sims_sys` call, a use-after-move, out-of-bounds indexing on empty input, and a constructor overload that silently built an invalid permutation. |
| DrudgeCAS/libcanon#13 | `form_orbits` now closes the orbit relation, so refinement is invariant under a node's own symmetry. |
| DrudgeCAS/libcanon#15 | Coset labelling by the pre-image, matching the rest of the library and the thesis. |
| DrudgeCAS/libcanon#18 | Rebuilds the automorphism chain so the refiner's greedy pruning is a real minimization. |

The last three fix cases where two spellings of the same eldag canonicalized to different forms. A randomized isomorphism-invariance fuzz goes from 2 failures per seed to 0 across 8 seeds.

## Verification

macOS, Apple clang 21, libc++:

| libcanon pin | drudge test suite |
| --- | --- |
| `6785c39` (previous pin, C++14) | 162 passed, 2 skipped |
| `3d16d82` (post-C++20-migration, pre-fix) | 10 failed, 145 passed, 7 errors |
| `e15bef1` (this PR) | **162 passed, 2 skipped** |

Canonical forms are unchanged, which is the intended outcome: the CCD energy and T2 amplitude equations derived through `PartHoleDrudge` are byte-identical to those from the previous pin.

The `Windows Build + Test` job has failed on every run since at least 2026-03-01, always with `C2280` on `Cell_it::operator=`. libcanon#11 fixes that, and this bump is what brings it in. I confirmed it directly by dispatching that job against a branch carrying the fix: https://github.com/DrudgeCAS/drudge/actions/runs/31874665781

🤖 Generated with [Claude Code](https://claude.com/claude-code)
