### PR TITLE
style: Pin down the ruff rule set and reformat

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -4,6 +4,12 @@ exclude = ["deps"]
 extend-include = ["*.drs"]
 
 [lint]
+# State the rule set explicitly.  Leaving it implicit means inheriting
+# whatever ruff's defaults happen to be, and those change between releases:
+# ruff 0.16 widened them, which turned a green tree into 244 errors without
+# a line of this project's code changing.  These four are ruff's classic
+# defaults, which is what this project has been linted against.
+select = ["E4", "E7", "E9", "F"]
 ignore = ["E741"]
 
 [format]

--- a/drudge/drudge.py
+++ b/drudge/drudge.py
@@ -963,9 +963,9 @@ class Tensor:
                 # Special optimization when we just have one term.
                 other_term = other_terms[0]
                 prod = self._terms.map(
-                    lambda term: (other_term, term)
-                    if right
-                    else (term, other_term)
+                    lambda term: (
+                        (other_term, term) if right else (term, other_term)
+                    )
                 )
 
             free_vars = set.union(*[i.free_vars for i in other_terms])


### PR DESCRIPTION
The `Lint and Format` job has failed on every run since 2026-03-01. It last passed on 2026-02-01. Neither failure is about this project's code — both are ruff version drift.

## Cause 1 — the rule set was implicit, and ruff's defaults moved

`.ruff.toml` had no `select`, only `ignore = ["E741"]`. That means the rule set was whatever ruff's defaults happened to be at the time. Ruff 0.16 widened those defaults, and a tree that was clean became 244 errors, across rules the project never opted into:

```
49  UP032    f-string
47  B008     function-call-in-default-argument
32  I001     unsorted-imports
27  UP006    non-pep585-annotation
12  PLR1711  useless-return
 9  PIE790   unnecessary-placeholder
...
```

Measured on unmodified `master`:

| ruff | `format --check` | `check` |
| --- | --- | --- |
| 0.14.14 (last green run) | clean | clean |
| 0.16.3 (current) | 1 file to reformat | **244 errors** |

The fix is to say what the project actually lints against, rather than inheriting a moving target. `select = ["E4", "E7", "E9", "F"]` are ruff's classic defaults, which is what this code has always been checked with. With that stated explicitly, ruff 0.16.3 reports `All checks passed!` and 0.14.14 is unchanged.

## Cause 2 — a formatter style change

Ruff 0.16 formats a conditional expression inside a lambda argument differently, wrapping it in parentheses. That is one hunk in `drudge/drudge.py`. Applied here. Both 0.14.14 and 0.16.3 accept the result, so this does not trade one version's breakage for another's.

## Verification

| | ruff 0.14.14 | ruff 0.16.3 |
| --- | --- | --- |
| `ruff format --check .` | clean | clean |
| `ruff check .` | clean | clean |

Test suite unaffected: 162 passed, 2 skipped. The only code change is whitespace and parentheses.

## Note on scope

This deliberately does not adopt the 244 findings. Rules like `I001` (import sorting), `UP006`/`UP007` (PEP 585/604 annotations) and `B008` are reasonable things to adopt, but each is a broad, opinionated change to code style across the package, and adopting them silently as a side effect of a ruff upgrade is the wrong way round. If you want any of them, they are a deliberate choice to make rule by rule, and I am happy to do that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
