### PR TITLE
ci: Refresh uv.lock in the release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,3 +15,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
+
+      # `uv.lock` records this project's own version, and CI runs
+      # `uv sync --locked`, so the lock has to move with the version bump in
+      # `pyproject.toml`.  release-please does not know about it, so refresh
+      # it on the release branch it just wrote.
+      - name: Check out the release branch
+        if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.pr != '' }}
+        uses: actions/checkout@v6
+        with:
+          ref: release-please--branches--master--components--drudge
+          fetch-depth: 0
+
+      - name: Install uv
+        if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.pr != '' }}
+        uses: astral-sh/setup-uv@v7
+
+      - name: Refresh uv.lock and push if it changed
+        if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.pr != '' }}
+        run: |
+          uv lock
+          if git diff --quiet uv.lock; then
+            echo "uv.lock already matches the release version"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: Update uv.lock for the release version"
+          git push

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,8 +14,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-<<<<<<< HEAD
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
 
       # `uv.lock` records this project's own version, and CI runs
@@ -51,8 +50,3 @@ jobs:
           git add uv.lock
           git commit -m "chore: Update uv.lock for the release version"
           git push
-||||||| f118525
-      - uses: googleapis/release-please-action@v4
-=======
-      - uses: googleapis/release-please-action@v5
->>>>>>> origin/master

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,18 +22,23 @@ jobs:
       # `pyproject.toml`.  release-please does not know about it, so refresh
       # it on the release branch it just wrote.
       - name: Check out the release branch
-        if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.pr != '' }}
+        if: ${{ steps.release.outputs.pr != '' }}
         uses: actions/checkout@v6
         with:
-          ref: release-please--branches--master--components--drudge
-          fetch-depth: 0
+          ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+
+      - name: Set up Python
+        if: ${{ steps.release.outputs.pr != '' }}
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: pyproject.toml
 
       - name: Install uv
-        if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.pr != '' }}
+        if: ${{ steps.release.outputs.pr != '' }}
         uses: astral-sh/setup-uv@v7
 
       - name: Refresh uv.lock and push if it changed
-        if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.pr != '' }}
+        if: ${{ steps.release.outputs.pr != '' }}
         run: |
           uv lock
           if git diff --quiet uv.lock; then


### PR DESCRIPTION
The automated release path has never worked end to end. #56 fails CI before it starts to build, and the last release, 0.11.1, had to be cut by hand (`chore: manual release v0.11.1`). This is why.

## The problem

`uv.lock` records the project's own version:

```
name = "drudge"
version = "0.11.1"
source = { editable = "." }
```

release-please bumps the version in `pyproject.toml`, `drudge/__init__.py` and `CITATION.cff`, but it knows nothing about `uv.lock`. CI then runs `uv sync --locked`, which refuses to proceed:

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
hint: To update the lockfile, run `uv lock`.
```

Every release PR hits this, on all three platforms, before a single file is compiled.

## The fix

After release-please writes the release branch, check that branch out, run `uv lock`, and push if anything changed. The resulting diff is one line, the project's own version.

The step is a no-op when the lock already matches, so it does nothing on ordinary pushes to `master`.

## Verified

I applied the same change by hand to #56's branch and its CI went from three failing build jobs to all five green.

## A related note for reviewers

While fixing #56 I also found that its changelog was missing two of the three changes in the release. #69, the libcanon bump, landed as `chore(deps):` and #70 as `style:`. Both types are hidden from release-please's changelog by default, so no amount of regenerating would surface them — I confirmed that by dispatching the workflow and watching the PR come back byte-identical.

That was my error in the commit subjects, not a tooling problem: a dependency bump whose purpose is to fix correctness bugs should be `fix(deps):`, not `chore(deps):`. I have added those entries to #56 by hand.

The types that reach the changelog are `feat`, `fix`, `perf`, `deps` and `revert`. `chore`, `style`, `ci`, `docs`, `refactor`, `test` and `build` do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
