### PR TITLE
Add electron-phonon drudges

### DIFF
--- a/drudge/__init__.py
+++ b/drudge/__init__.py
@@ -23,6 +23,12 @@ from .fock import (
     SpinOneHalfPartHoleDrudge,
     RestrictedPartHoleDrudge,
     BogoliubovDrudge,
+    MixDrudge,
+    GenEPhDrudge,
+    RestrictedGenEPhDrudge,
+    PartHoleEPhDrudge,
+    SpinOneHalfPartHoleEPhDrudge,
+    RestrictedPartHoleEPhDrudge,
 )
 from .genquad import GenQuadDrudge, GenQuadLatticeDrudge
 from .su2 import SU2LatticeDrudge
@@ -75,6 +81,12 @@ __all__ = [
     "SpinOneHalfPartHoleDrudge",
     "RestrictedPartHoleDrudge",
     "BogoliubovDrudge",
+    "MixDrudge",
+    "GenEPhDrudge",
+    "RestrictedGenEPhDrudge",
+    "PartHoleEPhDrudge",
+    "SpinOneHalfPartHoleEPhDrudge",
+    "RestrictedPartHoleEPhDrudge",
     #
     # Other algebraic systems.
     "GenQuadDrudge",

--- a/drudge/fock.py
+++ b/drudge/fock.py
@@ -1357,3 +1357,870 @@ class BogoliubovDrudge(GenMBDrudge):
         name.
         """
         return self.eval_phys_vev(tensor)
+
+
+class MixDrudge(FockDrudge):
+    """Drudge for independent fermion and boson operator algebras.
+
+    Fermion operators are kept to the left of boson operators.  Operators from
+    the two sectors commute and have no cross contractions.  Normal ordering
+    is performed independently in the fermion and boson sectors.
+    """
+
+    def __init__(self, *args, fermion_labels, boson_labels, **kwargs):
+        super().__init__(*args, exch=BOSE, **kwargs)
+
+        self.fermion_labels = frozenset(fermion_labels)
+        self.boson_labels = frozenset(boson_labels)
+
+        overlap = self.fermion_labels & self.boson_labels
+        if overlap:
+            raise ValueError(
+                "Operator labels cannot be both fermionic and bosonic",
+                overlap,
+            )
+
+        self._mixed_labels = self.fermion_labels | self.boson_labels
+
+    @property
+    def ancr_contractor(self):
+        """Contract equal operator species and reject cross contractions."""
+
+        return functools.partial(
+            _contr_mixed_ancr_by_delta, known_labels=self._mixed_labels
+        )
+
+    def normal_order(self, terms: RDD, **kwargs):
+        """Normal order fermions and bosons in separate Wick passes."""
+
+        if len(kwargs) != 0:
+            raise ValueError("Invalid arguments to mixed normal order", kwargs)
+
+        op_parser = self.op_parser
+        fermion_labels = self.fermion_labels
+        boson_labels = self.boson_labels
+
+        terms = terms.map(
+            functools.partial(
+                _partition_mixed_ops,
+                fermion_labels=fermion_labels,
+                boson_labels=boson_labels,
+                op_parser=op_parser,
+            )
+        )
+
+        contractor = self.contractor
+        fermion_comparator = functools.partial(
+            _compare_mixed_sector_ops,
+            sector_labels=fermion_labels,
+            op_parser=op_parser,
+        )
+        boson_comparator = functools.partial(
+            _compare_mixed_sector_ops,
+            sector_labels=boson_labels,
+            op_parser=op_parser,
+        )
+
+        terms = WickDrudge.normal_order(
+            self,
+            terms,
+            comparator=fermion_comparator,
+            contractor=contractor,
+            phase=FERMI,
+        )
+        terms = WickDrudge.normal_order(
+            self,
+            terms,
+            comparator=boson_comparator,
+            contractor=contractor,
+            phase=BOSE,
+        )
+
+        return terms.filter(
+            functools.partial(
+                _is_not_zero_by_mixed_nilp,
+                fermion_labels=fermion_labels,
+                op_parser=op_parser,
+            )
+        )
+
+    def eval_phys_vev(self, tensor: Tensor):
+        """Evaluate the vacuum expectation value of mixed field operators."""
+
+        terms = self.normal_order(tensor.terms)
+        return Tensor(self, terms.filter(lambda term: term.is_scalar))
+
+
+class GenEPhDrudge(MixDrudge):
+    """Drudge for general systems containing fermions and bosons.
+
+    This class configures independent fermion and boson field operators and
+    their orbital ranges.  Fermion spin can be disabled, given by explicit
+    values, or represented by a symbolic range.
+
+    .. attribute:: fermi_op
+
+        The vector base for fermion field operators.
+
+    .. attribute:: fermi_cr
+
+        The base for fermion creation operators.
+
+    .. attribute:: fermi_an
+
+        The base for fermion annihilation operators.
+
+    .. attribute:: bose_op
+
+        The vector base for boson field operators.
+
+    .. attribute:: bose_cr
+
+        The base for boson creation operators.
+
+    .. attribute:: bose_an
+
+        The base for boson annihilation operators.
+
+    .. attribute:: fermi_density
+
+        The one-fermion density matrix used by :meth:`eval_mf_vev`.
+
+    .. attribute:: H1e
+
+        The one-electron part of the Hamiltonian.
+
+    .. attribute:: H2e
+
+        The two-electron part of the Hamiltonian.
+
+    .. attribute:: Hb
+
+        The free-boson part of the Hamiltonian.
+
+    .. attribute:: Heph
+
+        The electron-boson coupling part of the Hamiltonian.
+    """
+
+    DEFAULT_FERMI_DUMMS = symbols("p q r s") + tuple(
+        Symbol("p{}".format(i)) for i in range(21)
+    )
+    DEFAULT_BOSE_DUMMS = symbols("x y z") + tuple(
+        Symbol("x{}".format(i)) for i in range(21)
+    )
+    DEFAULT_SPIN_DUMMS = tuple(
+        Symbol("sigma{}".format(i)) for i in range(50)
+    )
+
+    def __init__(
+        self,
+        *args,
+        fermi_op_label="c",
+        bose_op_label="b",
+        fermi_orb=((Range("F"), DEFAULT_FERMI_DUMMS),),
+        bose_orb=((Range("B"), DEFAULT_BOSE_DUMMS),),
+        spin=(),
+        fermi_density=IndexedBase("rho"),
+        one_body=IndexedBase("h"),
+        two_body=IndexedBase("u"),
+        dbbar=True,
+        boson_energy=IndexedBase("w"),
+        eph_coupling=IndexedBase("g"),
+        **kwargs,
+    ):
+        """Initialize a general mixed fermion-boson drudge.
+
+        Parameters
+        ----------
+
+        fermi_op_label
+            The label for fermion field operators.
+
+        bose_op_label
+            The label for boson field operators.
+
+        fermi_orb
+            An iterable of range and dummy pairs for fermion orbital indices.
+
+        bose_orb
+            An iterable of range and dummy pairs for boson orbital indices.
+
+        spin
+            The fermion spin specification.  An empty sequence disables spin.
+            Explicit spin values or a symbolic range and dummy pair can also
+            be given, as in :class:`GenMBDrudge`.
+
+        fermi_density
+            The indexed base for the one-fermion density matrix.
+
+        one_body
+            The indexed base for the one-electron matrix elements.
+
+        two_body
+            The indexed base for the two-electron interaction tensor.
+
+        dbbar
+            If the two-electron interaction is antisymmetrized.  The default
+            antisymmetrized form is odd under exchange within either index
+            pair and has a coefficient of one quarter.  The Coulomb form
+            obeys ``u[p, q, r, s] = u[r, s, p, q]`` and has a coefficient of
+            one half.
+
+        boson_energy
+            The indexed base for the boson energies.
+
+        eph_coupling
+            The indexed base for the electron-boson coupling tensor.
+
+        """
+
+        super().__init__(
+            *args,
+            fermion_labels=(fermi_op_label,),
+            boson_labels=(bose_op_label,),
+            **kwargs,
+        )
+
+        self.default_einst = True
+
+        fermi_op = Vec(fermi_op_label)
+        fermi_cr = fermi_op[CR]
+        fermi_an = fermi_op[AN]
+        self.fermi_op_label = fermi_op_label
+        self.fermi_op = fermi_op
+        self.fermi_cr = fermi_cr
+        self.fermi_an = fermi_an
+
+        bose_op = Vec(bose_op_label)
+        bose_cr = bose_op[CR]
+        bose_an = bose_op[AN]
+        self.bose_op_label = bose_op_label
+        self.bose_op = bose_op
+        self.bose_cr = bose_cr
+        self.bose_an = bose_an
+
+        self.set_name(
+            **{
+                str(fermi_op) + "_": fermi_an,
+                str(fermi_op) + "_dag": fermi_cr,
+                str(fermi_op) + "dag_": fermi_cr,
+                str(bose_op) + "_": bose_an,
+                str(bose_op) + "_dag": bose_cr,
+                str(bose_op) + "dag_": bose_cr,
+            }
+        )
+
+        fermi_orb_ranges = []
+        for range_, dumms in fermi_orb:
+            self.set_dumms(range_, dumms)
+            fermi_orb_ranges.append(range_)
+        self.fermi_orb_ranges = fermi_orb_ranges
+
+        bose_orb_ranges = []
+        for range_, dumms in bose_orb:
+            self.set_dumms(range_, dumms)
+            bose_orb_ranges.append(range_)
+        self.bose_orb_ranges = bose_orb_ranges
+
+        spin = list(spin)
+        if len(spin) == 0:
+            has_spin = False
+            spin_range = None
+            self.spin_vals = None
+            self.spin_range = None
+            self.spin_dumms = None
+        elif isinstance(spin[0], Range):
+            has_spin = True
+            if len(spin) != 2:
+                raise ValueError(
+                    "Invalid spin specification",
+                    spin,
+                    "expecting range/dummies pair.",
+                )
+            spin_range = spin[0]
+            self.spin_dumms = self.set_dumms(spin_range, spin[1])
+            self.spin_vals = None
+            self.spin_range = spin_range
+        else:
+            has_spin = True
+            spin_vals = [ensure_expr(i) for i in spin]
+            if len(spin_vals) == 1:
+                warnings.warn(
+                    "Just one spin value is given: "
+                    "consider dropping it for better performance"
+                )
+            spin_range = spin_vals
+            self.spin_vals = spin_vals
+            self.spin_range = None
+            self.spin_dumms = None
+
+        self.fermi_density = fermi_density
+        self.set_name(fermi_density)
+
+        self.add_resolver_for_dumms()
+
+        # Temporary dummies allow the fermion orbital space to be a direct sum
+        # of multiple ranges.  They are reset to conventional dummies after the
+        # Hamiltonian terms have been formed.
+        orb_dumms = tuple(
+            Symbol("internalFermiOrbitPlaceholder{}".format(i))
+            for i in range(4)
+        )
+        spin_dumms = tuple(
+            Symbol("internalSpinPlaceholder{}".format(i)) for i in range(2)
+        )
+
+        orb_sums = [(i, fermi_orb_ranges) for i in orb_dumms]
+        spin_sums = [(i, spin_range) for i in spin_dumms]
+        bose_orb_dumm = Symbol("internalBosonOrbitPlaceholder")
+        bose_orb_sum = (bose_orb_dumm, bose_orb_ranges)
+
+        self.one_body = one_body
+        self.set_name(one_body)
+        one_body_sums = orb_sums[:2]
+        if has_spin:
+            one_body_sums.append(spin_sums[0])
+            one_body_ops = (
+                fermi_cr[orb_dumms[0], spin_dumms[0]]
+                * fermi_an[orb_dumms[1], spin_dumms[0]]
+            )
+        else:
+            one_body_ops = (
+                fermi_cr[orb_dumms[0]] * fermi_an[orb_dumms[1]]
+            )
+        self.H1e = self.sum(
+            *one_body_sums,
+            one_body[orb_dumms[:2]] * one_body_ops,
+        ).reset_dumms()
+
+        self.two_body = two_body
+        self.dbbar = bool(dbbar)
+        if self.dbbar:
+            two_body_coeff = Rational(1, 4)
+            self.set_symm(
+                two_body,
+                Perm([1, 0, 2, 3], NEG),
+                Perm([0, 1, 3, 2], NEG),
+                valence=4,
+            )
+        else:
+            two_body_coeff = Rational(1, 2)
+            self.set_symm(
+                two_body,
+                Perm([2, 3, 0, 1], IDENT),
+                valence=4,
+            )
+        two_body_sums = list(orb_sums)
+        if has_spin:
+            two_body_sums.extend(spin_sums)
+            if self.dbbar:
+                two_body_ops = (
+                    fermi_cr[orb_dumms[0], spin_dumms[0]]
+                    * fermi_cr[orb_dumms[1], spin_dumms[1]]
+                    * fermi_an[orb_dumms[3], spin_dumms[1]]
+                    * fermi_an[orb_dumms[2], spin_dumms[0]]
+                )
+            else:
+                two_body_ops = (
+                    fermi_cr[orb_dumms[0], spin_dumms[0]]
+                    * fermi_cr[orb_dumms[2], spin_dumms[1]]
+                    * fermi_an[orb_dumms[3], spin_dumms[1]]
+                    * fermi_an[orb_dumms[1], spin_dumms[0]]
+                )
+        else:
+            if self.dbbar:
+                two_body_ops = (
+                    fermi_cr[orb_dumms[0]]
+                    * fermi_cr[orb_dumms[1]]
+                    * fermi_an[orb_dumms[3]]
+                    * fermi_an[orb_dumms[2]]
+                )
+            else:
+                two_body_ops = (
+                    fermi_cr[orb_dumms[0]]
+                    * fermi_cr[orb_dumms[2]]
+                    * fermi_an[orb_dumms[3]]
+                    * fermi_an[orb_dumms[1]]
+                )
+        self.H2e = self.sum(
+            *two_body_sums,
+            two_body_coeff * two_body[orb_dumms] * two_body_ops,
+        ).reset_dumms()
+
+        self.boson_energy = boson_energy
+        self.set_name(boson_energy)
+        self.Hb = self.sum(
+            bose_orb_sum,
+            boson_energy[bose_orb_dumm]
+            * bose_cr[bose_orb_dumm]
+            * bose_an[bose_orb_dumm],
+        ).reset_dumms()
+
+        self.eph_coupling = eph_coupling
+        self.set_name(eph_coupling)
+        eph_sums = [bose_orb_sum, *orb_sums[:2]]
+        if has_spin:
+            eph_sums.append(spin_sums[0])
+            eph_fermi_ops = (
+                fermi_cr[orb_dumms[0], spin_dumms[0]]
+                * fermi_an[orb_dumms[1], spin_dumms[0]]
+            )
+        else:
+            eph_fermi_ops = (
+                fermi_cr[orb_dumms[0]] * fermi_an[orb_dumms[1]]
+            )
+        self.Heph = self.sum(
+            *eph_sums,
+            eph_coupling[
+                bose_orb_dumm, orb_dumms[0], orb_dumms[1]
+            ]
+            * eph_fermi_ops
+            * (bose_cr[bose_orb_dumm] + bose_an[bose_orb_dumm]),
+        ).reset_dumms()
+
+        orig_ham = (self.H1e + self.H2e + self.Hb + self.Heph).reset_dumms()
+        self.orig_ham = orig_ham
+
+        simpled_ham = orig_ham.simplify()
+        self.ham = simpled_ham
+
+        self.set_tensor_method("eval_mf_vev", self.eval_mf_vev)
+
+    def eval_mf_vev(self, tensor: Tensor):
+        """Evaluate a mean-field VEV over the boson vacuum.
+
+        Bosons are contracted with the physical-vacuum contractor.  Fermions
+        are contracted by the one-body density matrix.  For spin-free
+        operators, ``<c_dag[p] c[q]>`` is ``rho[q, p]``.  Additional fermion
+        indices are matched by Kronecker deltas.
+        """
+
+        terms = self.normal_order(tensor.terms)
+        terms = terms.filter(
+            functools.partial(
+                _has_eph_op_counts,
+                fermion_labels=self.fermion_labels,
+                boson_labels=self.boson_labels,
+                n_bosons=0,
+            )
+        )
+
+        contractor = functools.partial(
+            _contr_fermi_density,
+            fermion_labels=self.fermion_labels,
+            density=self.fermi_density,
+            op_parser=self.op_parser,
+        )
+        terms = WickDrudge.normal_order(
+            self,
+            terms,
+            comparator=None,
+            contractor=contractor,
+            phase=FERMI,
+        )
+        return Tensor(self, terms)
+
+
+class RestrictedGenEPhDrudge(GenEPhDrudge):
+    """General electron-phonon drudge with symbolic restricted spin."""
+
+    def __init__(
+        self,
+        *args,
+        spin_range=Range(r"\uparrow\downarrow", 0, 2),
+        spin_dumms=GenEPhDrudge.DEFAULT_SPIN_DUMMS,
+        dbbar=False,
+        **kwargs,
+    ):
+        """Initialize the restricted general electron-phonon drudge."""
+
+        super().__init__(
+            *args,
+            spin=(spin_range, spin_dumms),
+            dbbar=dbbar,
+            **kwargs,
+        )
+        self.add_resolver({UP: spin_range, DOWN: spin_range})
+
+        self.spin_range = spin_range
+        self.spin_dumms = self.dumms.value[spin_range]
+
+
+class PartHoleEPhDrudge(GenEPhDrudge):
+    """Electron-phonon drudge using a fermion particle-hole convention.
+
+    Only fermion operators are interpreted relative to the Fermi vacuum.
+    Boson operators retain their ordinary creation and annihilation characters.
+
+    .. attribute:: orig_ham
+
+        The Hamiltonian before particle-hole normal ordering.
+
+    .. attribute:: full_ham
+
+        The full Hamiltonian normal-ordered relative to the fermion and boson
+        vacua and written in terms of the bare matrix elements.
+
+    .. attribute:: ham_energy
+
+        The scalar reference energy in the full Hamiltonian.
+
+    .. attribute:: one_body_ham
+
+        The fermion one-body part written in terms of bare matrix elements.
+
+    .. attribute:: ham
+
+        The non-scalar Hamiltonian with its fermion one-body part written in
+        terms of the Fock matrix.
+    """
+
+    DEFAULT_PART_DUMMS = PartHoleDrudge.DEFAULT_PART_DUMMS
+    DEFAULT_HOLE_DUMMS = PartHoleDrudge.DEFAULT_HOLE_DUMMS
+    DEFAULT_ORB_DUMMS = PartHoleDrudge.DEFAULT_ORB_DUMMS
+
+    def __init__(
+        self,
+        *args,
+        fermi_op_label="c",
+        part_orb=(Range("V", 0, Symbol("nv")), DEFAULT_PART_DUMMS),
+        hole_orb=(Range("O", 0, Symbol("no")), DEFAULT_HOLE_DUMMS),
+        all_orb_dumms=DEFAULT_ORB_DUMMS,
+        spin=(),
+        one_body=IndexedBase("h"),
+        two_body=IndexedBase("u"),
+        fock=IndexedBase("f"),
+        dbbar=True,
+        **kwargs,
+    ):
+        """Initialize the particle-hole electron-phonon drudge."""
+
+        self.part_range = part_orb[0]
+        self.hole_range = hole_orb[0]
+
+        super().__init__(
+            *args,
+            fermi_op_label=fermi_op_label,
+            fermi_orb=(part_orb, hole_orb),
+            spin=spin,
+            one_body=one_body,
+            two_body=two_body,
+            dbbar=dbbar,
+            **kwargs,
+        )
+
+        self.all_orb_dumms = tuple(all_orb_dumms)
+        self.set_name(*self.all_orb_dumms)
+        self.add_resolver(
+            {i: (self.part_range, self.hole_range) for i in all_orb_dumms}
+        )
+
+        full_ham = self.ham
+        full_ham.cache()
+        self.full_ham = full_ham
+
+        self.ham_energy = full_ham.filter(lambda term: term.is_scalar)
+
+        count_args = {
+            "fermion_labels": self.fermion_labels,
+            "boson_labels": self.boson_labels,
+        }
+        self.one_body_ham = full_ham.filter(
+            functools.partial(
+                _has_eph_op_counts,
+                n_fermions=2,
+                n_bosons=0,
+                **count_args,
+            )
+        )
+        self.two_body_ham = full_ham.filter(
+            functools.partial(
+                _has_eph_op_counts,
+                n_fermions=4,
+                n_bosons=0,
+                **count_args,
+            )
+        )
+        self.boson_ham = full_ham.filter(
+            functools.partial(
+                _has_eph_op_counts,
+                n_fermions=0,
+                n_bosons=2,
+                **count_args,
+            )
+        )
+        self.eph_ham = full_ham.filter(
+            functools.partial(
+                _has_eph_op_counts,
+                n_bosons=1,
+                **count_args,
+            )
+        )
+
+        # Rewrite the electronic one-body part in terms of Fock matrices.  As
+        # in PartHoleDrudge, the one-body terms generated from the two-body
+        # interaction are absorbed into the Fock matrix.
+        self.fock = fock
+        one_body_terms = []
+        for term in self.one_body_ham.local_terms:
+            if term.amp.has(one_body):
+                one_body_terms.append(term.subst({one_body: fock}))
+        rewritten_one_body_ham = self.create_tensor(one_body_terms)
+
+        other_ham = full_ham.filter(
+            functools.partial(
+                _keep_eph_ham_term,
+                **count_args,
+            )
+        )
+        ham = rewritten_one_body_ham + other_ham
+        ham.cache()
+        self.ham = ham
+
+        self.set_name(no=self.hole_range.size)
+        self.set_name(nv=self.part_range.size)
+
+    @property
+    def op_parser(self):
+        """Parse particle-hole characters for fermion operators only."""
+
+        resolvers = self.resolvers
+        hole_range = self.hole_range
+        fermion_labels = self.fermion_labels
+
+        def parse_parthole_eph_ops(op: Vec, term: Term):
+            """Parse a fermion or boson field operator."""
+
+            label, char, indices = parse_field_op(op, term)
+            if label not in fermion_labels:
+                return label, char, indices
+
+            orb_range = try_resolve_range(
+                indices[0], dict(term.sums), resolvers.value
+            )
+            if orb_range is None:
+                raise ValueError(
+                    "Invalid fermion orbit value",
+                    indices[0],
+                    "expecting particle or hole",
+                )
+            if orb_range == hole_range:
+                char = AN if char == CR else CR
+            return label, char, indices
+
+        return parse_parthole_eph_ops
+
+
+class SpinOneHalfPartHoleEPhDrudge(PartHoleEPhDrudge):
+    """Particle-hole electron-phonon drudge with explicit spin one-half.
+
+    The electronic interaction uses the Coulomb form inherited from
+    :class:`GenEPhDrudge`, with explicit spin indices.
+    """
+
+    def __init__(
+        self,
+        *args,
+        part_orb=(
+            Range("V", 0, Symbol("nv")),
+            PartHoleEPhDrudge.DEFAULT_PART_DUMMS + symbols("beta gamma"),
+        ),
+        hole_orb=(
+            Range("O", 0, Symbol("no")),
+            PartHoleEPhDrudge.DEFAULT_HOLE_DUMMS + symbols("u v"),
+        ),
+        spin=(UP, DOWN),
+        dbbar=False,
+        **kwargs,
+    ):
+        """Initialize the explicit-spin electron-phonon drudge."""
+
+        super().__init__(
+            *args,
+            part_orb=part_orb,
+            hole_orb=hole_orb,
+            spin=spin,
+            dbbar=dbbar,
+            **kwargs,
+        )
+
+
+class RestrictedPartHoleEPhDrudge(SpinOneHalfPartHoleEPhDrudge):
+    """Particle-hole electron-phonon drudge on a restricted reference."""
+
+    def __init__(
+        self,
+        *args,
+        spin_range=Range(r"\uparrow\downarrow", 0, 2),
+        spin_dumms=GenEPhDrudge.DEFAULT_SPIN_DUMMS,
+        **kwargs,
+    ):
+        """Initialize the restricted electron-phonon drudge."""
+
+        super().__init__(
+            *args,
+            spin=(spin_range, spin_dumms),
+            **kwargs,
+        )
+        self.add_resolver({UP: spin_range, DOWN: spin_range})
+
+        self.spin_range = spin_range
+        self.spin_dumms = self.dumms.value[spin_range]
+
+        sigma = self.spin_dumms[0]
+        p = Symbol("p")
+        q = Symbol("q")
+        self.e_ = TensorDef(
+            Vec("E"),
+            (p, q),
+            self.sum(
+                (sigma, spin_range),
+                self.fermi_cr[p, sigma] * self.fermi_an[q, sigma],
+            ),
+        )
+        self.set_name(e_=self.e_)
+
+
+def _partition_mixed_ops(
+    term: Term, fermion_labels, boson_labels, op_parser: FockDrudge.OP_PARSER
+):
+    """Stably place all fermion operators before all boson operators."""
+
+    fermions = []
+    bosons = []
+
+    for op in term.vecs:
+        label, _, _ = op_parser(op, term)
+        if label in fermion_labels:
+            fermions.append(op)
+        elif label in boson_labels:
+            bosons.append(op)
+        else:
+            raise ValueError(
+                "Unknown operator label in mixed Fock algebra", label
+            )
+
+    return term.map(
+        vecs=tuple(fermions + bosons),
+        skip_vecs=True,
+    )
+
+
+def _compare_mixed_sector_ops(
+    op1: Vec,
+    op2: Vec,
+    term: Term,
+    sector_labels,
+    op_parser: FockDrudge.OP_PARSER,
+):
+    """Compare operators only when both belong to the selected sector."""
+
+    label1, _, _ = op_parser(op1, term)
+    label2, _, _ = op_parser(op2, term)
+    if label1 in sector_labels and label2 in sector_labels:
+        return _compare_field_ops(op1, op2, term, op_parser=op_parser)
+
+    # Mixed operators have already been stably partitioned.  Operators in the
+    # other sector are intentionally left untouched during this pass.
+    return True
+
+
+def _has_eph_op_counts(
+    term: Term,
+    fermion_labels,
+    boson_labels,
+    n_fermions=None,
+    n_bosons=None,
+):
+    """Test the fermion and boson operator counts in a term."""
+
+    fermion_count = 0
+    boson_count = 0
+    for op in term.vecs:
+        if op.label in fermion_labels:
+            fermion_count += 1
+        elif op.label in boson_labels:
+            boson_count += 1
+        else:
+            raise ValueError(
+                "Unknown operator label in electron-phonon Hamiltonian",
+                op.label,
+            )
+
+    return (n_fermions is None or fermion_count == n_fermions) and (
+        n_bosons is None or boson_count == n_bosons
+    )
+
+
+def _keep_eph_ham_term(term: Term, fermion_labels, boson_labels):
+    """Keep non-scalar terms outside the bare fermion one-body part."""
+
+    if term.is_scalar:
+        return False
+    return not _has_eph_op_counts(
+        term,
+        fermion_labels=fermion_labels,
+        boson_labels=boson_labels,
+        n_fermions=2,
+        n_bosons=0,
+    )
+
+
+def _contr_fermi_density(
+    op1: Vec,
+    op2: Vec,
+    term: Term,
+    fermion_labels,
+    density: IndexedBase,
+    op_parser: FockDrudge.OP_PARSER,
+):
+    """Contract a creation-annihilation pair by a fermion density."""
+
+    label1, char1, indices1 = op_parser(op1, term)
+    label2, char2, indices2 = op_parser(op2, term)
+
+    if label1 not in fermion_labels or label2 not in fermion_labels:
+        return 0
+    if label1 != label2 or char1 != CR or char2 != AN:
+        return 0
+    if len(indices1) != len(indices2) or len(indices1) == 0:
+        raise ValueError(
+            "Invalid fermion operators to contract by density",
+            (indices1, indices2),
+        )
+
+    result = density[indices2[0], indices1[0]]
+    for index1, index2 in zip(indices1[1:], indices2[1:]):
+        result *= KroneckerDelta(index1, index2)
+    return result
+
+
+def _contr_mixed_ancr_by_delta(
+    label1, indices1, label2, indices2, known_labels
+):
+    """Contract equal mixed-field labels and return zero across labels."""
+
+    if label1 not in known_labels or label2 not in known_labels:
+        raise ValueError(
+            "Unknown operator label in mixed Fock contraction",
+            (label1, label2),
+        )
+    if label1 != label2:
+        return 0
+    return _contr_ancr_by_delta(label1, indices1, label2, indices2)
+
+
+def _is_not_zero_by_mixed_nilp(
+    term: Term, fermion_labels, op_parser: FockDrudge.OP_PARSER
+):
+    """Test nilpotency only for repeated identical fermion operators."""
+
+    vecs = term.vecs
+    for i in range(len(vecs) - 1):
+        if vecs[i] != vecs[i + 1]:
+            continue
+        label, _, _ = op_parser(vecs[i], term)
+        if label in fermion_labels:
+            return False
+    return True

--- a/drudge/fock.py
+++ b/drudge/fock.py
@@ -1509,6 +1509,7 @@ class GenEPhDrudge(MixDrudge):
     DEFAULT_BOSE_DUMMS = symbols("x y z") + tuple(
         Symbol("x{}".format(i)) for i in range(21)
     )
+    DEFAULT_BOSE_RANGE = Range("B", 0, Symbol("nb"))
     DEFAULT_SPIN_DUMMS = tuple(
         Symbol("sigma{}".format(i)) for i in range(50)
     )
@@ -1519,7 +1520,7 @@ class GenEPhDrudge(MixDrudge):
         fermi_op_label="c",
         bose_op_label="b",
         fermi_orb=((Range("F"), DEFAULT_FERMI_DUMMS),),
-        bose_orb=((Range("B"), DEFAULT_BOSE_DUMMS),),
+        bose_orb=((DEFAULT_BOSE_RANGE, DEFAULT_BOSE_DUMMS),),
         spin=(),
         fermi_density=IndexedBase("rho"),
         one_body=IndexedBase("h"),
@@ -1622,6 +1623,8 @@ class GenEPhDrudge(MixDrudge):
             self.set_dumms(range_, dumms)
             bose_orb_ranges.append(range_)
         self.bose_orb_ranges = bose_orb_ranges
+        if len(bose_orb_ranges) == 1 and bose_orb_ranges[0].bounded:
+            self.set_name(nb=bose_orb_ranges[0].size)
 
         spin = list(spin)
         if len(spin) == 0:
@@ -1845,6 +1848,19 @@ class RestrictedGenEPhDrudge(GenEPhDrudge):
 
         self.spin_range = spin_range
         self.spin_dumms = self.dumms.value[spin_range]
+
+        sigma = self.spin_dumms[0]
+        p = Symbol("p")
+        q = Symbol("q")
+        self.e_ = TensorDef(
+            Vec("E"),
+            (p, q),
+            self.sum(
+                (sigma, spin_range),
+                self.fermi_cr[p, sigma] * self.fermi_an[q, sigma],
+            ),
+        )
+        self.set_name(e_=self.e_)
 
 
 class PartHoleEPhDrudge(GenEPhDrudge):

--- a/drudge/wick.py
+++ b/drudge/wick.py
@@ -101,10 +101,10 @@ class WickDrudge(Drudge, abc.ABC):
         """
         comparator = kwargs.pop("comparator", self.comparator)
         contractor = kwargs.pop("contractor", self.contractor)
+        phase = kwargs.pop("phase", self.phase)
         if len(kwargs) != 0:
             raise ValueError("Invalid arguments to Wick normal order", kwargs)
 
-        phase = self.phase
         symms = self.symms
         resolvers = self.resolvers
 


### PR DESCRIPTION
## Summary

- Add mixed fermion-boson normal ordering.
- Add general and particle-hole electron-phonon drudges.
- Add mean-field-vacuum expectation evaluation.